### PR TITLE
Fixed In the NativeAOT-compatible McpxInterrop class, corrected Batch…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.5] - 2025-11-17
+### Fixed
+- Fixed In the NativeAOT-compatible McpxInterrop class, corrected BatchWriteBool to call BatchWrite with bool instead of short.
+
 ## [0.5.4] - 2025-09-03
 ### Fixed
 - Fixed an issue in the BatchRead method where specifying types larger than 32 bits resulted in an incorrect read count.

--- a/CHANGELOG_JA.md
+++ b/CHANGELOG_JA.md
@@ -1,3 +1,7 @@
+## [0.5.5] - 2025-11-17
+### Fixed
+- NativeAOT対応のMcpxInterropクラスにて、BatchWriteBoolのBatchWrite呼び出しがshortを使用していた不具合を修正（boolに変更）
+
 ## [0.5.4] - 2025-09-03
 ### Fixed
 - BatchReadメソッドで32ビット以上の型を指定した場合、読み出し点数が正しく計算されない不具合を修正

--- a/McpXInterop/McpXInterop.cs
+++ b/McpXInterop/McpXInterop.cs
@@ -109,7 +109,7 @@ public static class McpXInterop
     [UnmanagedCallersOnly(EntryPoint = "batch_write_bool")]
     public static int BatchWriteBool(int connectionId, IntPtr outValues, Device device, int length)
     {
-        return BatchWrite<short>(connectionId, outValues, device, length);
+        return BatchWrite<bool>(connectionId, outValues, device, length);
     }
 
     private static int BatchRead<T>(int connectionId, IntPtr outValues, Device device, int length) where T : unmanaged

--- a/McpXLib/McpXLib.csproj
+++ b/McpXLib/McpXLib.csproj
@@ -30,7 +30,7 @@
 
   <PropertyGroup>
     <PackageId>McpX</PackageId>
-    <Version>0.5.4</Version>
+    <Version>0.5.5</Version>
     <Authors>Yudai Kitamura</Authors>
     <Company></Company>
     <Description>MC protocol communication library for Mitsubishi PLC(三菱PLC用MCプロトコル通信ライブラリ)</Description>

--- a/McpXLib/README.md
+++ b/McpXLib/README.md
@@ -63,3 +63,6 @@ using (var mcpx = new McpX("192.168.12.88", 10000))
 
 ## Changelog
 - [CHANGELOG.md](https://github.com/YudaiKitamura/McpX/blob/main/CHANGELOG.md)
+
+## Related
+- [mcpx-mcp-server](https://github.com/YudaiKitamura/mcpx-mcp-server) An MCP(Model Context Protocol) server that enables real-time access to Mitsubishi Electric PLC devices from generative AI.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="docfx/images/mcpx_ogp.png" alt="logo" />
 <br>
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-0.5.4-blue" />
+  <img alt="Version" src="https://img.shields.io/badge/version-0.5.5-blue" />
   <img alt=".NET 7.0+" src="https://img.shields.io/badge/.NET-7.0+-blueviolet" />
   <img alt=".NET 8.0+" src="https://img.shields.io/badge/.NET-8.0+-purple" />
   <img alt=".NET 9.0+" src="https://img.shields.io/badge/.NET-9.0+-indigo" />
@@ -78,3 +78,6 @@ using (var mcpx = new McpX("192.168.12.88", 10000))
 
 ## Changelog
 - [CHANGELOG.md](./CHANGELOG.md)
+
+## Related
+- [mcpx-mcp-server](https://github.com/YudaiKitamura/mcpx-mcp-server) An MCP(Model Context Protocol) server that enables real-time access to Mitsubishi Electric PLC devices from generative AI.

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,7 +1,7 @@
 <img src="docfx/images/mcpx_ogp.png" alt="logo" />
 <br>
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-0.5.4-blue" />
+  <img alt="Version" src="https://img.shields.io/badge/version-0.5.5-blue" />
   <img alt=".NET 7.0+" src="https://img.shields.io/badge/.NET-7.0+-blueviolet" />
   <img alt=".NET 8.0+" src="https://img.shields.io/badge/.NET-8.0+-purple" />
   <img alt=".NET 9.0+" src="https://img.shields.io/badge/.NET-9.0+-indigo" />
@@ -78,3 +78,6 @@ using (var mcpx = new McpX("192.168.12.88", 10000))
 
 ## 変更履歴
 - [CHANGELOG_JA.md](./CHANGELOG_JA.md)
+
+## 関連
+- [mcpx-mcp-server](https://github.com/YudaiKitamura/mcpx-mcp-server) 生成AIから三菱電機製 PLC のデバイスへリアルタイムアクセスを可能にする MCP(Model Context Protocol)サーバー


### PR DESCRIPTION
…WriteBool to call BatchWrite with bool instead of short